### PR TITLE
Update script URL.

### DIFF
--- a/basicbijbel.php
+++ b/basicbijbel.php
@@ -21,7 +21,7 @@ GitHub URI: https://github.com/pronamic/wp-basicbijbel
 function basicbijbel_enqueue_scripts() {
 	wp_enqueue_script(
 		'basicbijbel',
-		'//www.basicbijbel.nl/scan',
+		'https://www.basisbijbel.nl/scan',
 		array( 'jquery' ),
 		false,
 		true


### PR DESCRIPTION
Script URL updated, as https://www.basicbijbel.nl does not have a valid SSL certificate.